### PR TITLE
chore: updated release-it.json config

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,10 @@
 {
+  "git": {
+    "commitMessage": "chore: release v${version}"
+  },
   "github": {
     "release": true,
+    "releaseName": "v${version}",
     "skipChecks": true
   },
   "npm": {
@@ -8,8 +12,6 @@
     "skipChecks": true
   },
   "hooks": {
-    "before:init": [
-      "yarn build"
-    ]
+    "before:init": ["yarn lint", "yarn build"]
   }
 }


### PR DESCRIPTION
Hi, @sir-dunxalot,

this PR is based on our discussion started in another PR: https://github.com/sir-dunxalot/cypress-nextjs-auth0/pull/44#discussion_r804898609.

And I am sorry that there is [one commit](https://github.com/sir-dunxalot/cypress-nextjs-auth0/commit/025be00d195041d8fa6090b42886ac8b5e390714) and a [revert-commit](https://github.com/sir-dunxalot/cypress-nextjs-auth0/commit/d7302a691a70a9328a6b5546dfe8d2d0e08671e2) on the main branch. 🤦‍♂️ I forgot to switch the repo in my VS Code and pushed too early... I reverted it and this is the PR for it. Sorry again. :(