### PR TITLE
feat: cache sessions for multiple users

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,53 +1,46 @@
-let cachedUsername;
+let sessionStore = {};
 
 Cypress.Commands.add('login', (credentials = {}) => {
   const { username, password } = credentials;
-  const cachedUserIsCurrentUser = cachedUsername && cachedUsername === username;
   const _credentials = {
     username: username || Cypress.env('auth0Username'),
     password: password || Cypress.env('auth0Password'),
   };
 
-  const sessionCookieName = Cypress.env('auth0SessionCookieName');
-
   /* https://github.com/auth0/nextjs-auth0/blob/master/src/handlers/login.ts#L70 */
 
   try {
-    cy.getCookie(sessionCookieName).then(cookieValue => {
-      /* Skip logging in again if session already exists */
+    const session = sessionStore[username];
+    if (session) {
+      cy._setAuth0Cookie(session);
+    } else {
+      cy.getUserTokens(_credentials).then(response => {
+        const { accessToken, expiresIn, idToken, scope } = response;
 
-      if (cookieValue && cachedUserIsCurrentUser) {
-        return true;
-      } else {
-        cy.clearCookies();
+        cy.getUserInfo(accessToken).then(user => {
+          /* https://github.com/auth0/nextjs-auth0/blob/master/src/handlers/callback.ts#L44 */
+          /* https://github.com/auth0/nextjs-auth0/blob/master/src/handlers/callback.ts#L47 */
+          /* https://github.com/auth0/nextjs-auth0/blob/master/src/session/cookie-store/index.ts#L57 */
 
-        cy.getUserTokens(_credentials).then(response => {
-          const { accessToken, expiresIn, idToken, scope } = response;
+          const payload = {
+            secret: Cypress.env('auth0CookieSecret'),
+            user,
+            idToken,
+            accessToken,
+            accessTokenScope: scope,
+            accessTokenExpiresAt: Date.now() + expiresIn,
+            createdAt: Date.now(),
+          };
 
-          cy.getUserInfo(accessToken).then(user => {
-            /* https://github.com/auth0/nextjs-auth0/blob/master/src/handlers/callback.ts#L44 */
-            /* https://github.com/auth0/nextjs-auth0/blob/master/src/handlers/callback.ts#L47 */
-            /* https://github.com/auth0/nextjs-auth0/blob/master/src/session/cookie-store/index.ts#L57 */
+          /* https://github.com/auth0/nextjs-auth0/blob/master/src/session/cookie-store/index.ts#L73 */
 
-            const payload = {
-              secret: Cypress.env('auth0CookieSecret'),
-              user,
-              idToken,
-              accessToken,
-              accessTokenScope: scope,
-              accessTokenExpiresAt: Date.now() + expiresIn,
-              createdAt: Date.now(),
-            };
-
-            /* https://github.com/auth0/nextjs-auth0/blob/master/src/session/cookie-store/index.ts#L73 */
-
-            cy.task('encrypt', payload).then(encryptedSession => {
-              cy._setAuth0Cookie(encryptedSession);
-            });
+          cy.task('encrypt', payload).then(encryptedSession => {
+            sessionStore[username] = encryptedSession;
+            cy._setAuth0Cookie(encryptedSession);
           });
         });
-      }
-    });
+      });
+    }
   } catch (error) {
     // throw new Error(error);
   }


### PR DESCRIPTION
## Description

Closes #25 

Serve encrypted sessions directly from an in-memory cache, performing a full login when necessary on a cache miss. This should happen only once for each user in a test run, alleviating some pressure on the Auth0 API, particularly in CI environments where multiple copies of the suite may run in parallel.

## How to test

The Cypress terminal window will output http logs indicating that a programmatic login has occurred:

```bash
POST /oauth/token 200 978.683 ms - -
GET /userinfo 200 409.344 ms - -
```

I simply ran my Cypress suite of 40 tests against both this branch and `main`, and counted how many times these log entries appeared. On `main`, I saw 22 instances. On this branch, I saw 9 -- one for each user in the test suite -- without any loss in functionality.

One thing to note: if any test updates the Cypress superdomain, it seems that the Cypress window is reset and the cache is lost. I'm curious if there's another way to store the cache such that it persists across superdomain updates.