### PR TITLE
feat: add realm to login function

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Grant Type:
 
 ![auth0-grant-types](https://user-images.githubusercontent.com/4495352/83317105-6fed3780-a1f8-11ea-8d86-192e7e25f84b.jpg)
 
-**Step 6.2**: Go to your
+**Step 6.2**: 
+
+**OPTION A:** Go to your
 [Auth0 tenant's settings](https://manage.auth0.com/#/tenant) (make sure tenant
 name is correct in top-left of the page) and set the default directory to
 `Username-Password-Authentication`:
@@ -128,6 +130,15 @@ If you have changed the name of your default directory (i.e. your tenant's
 default database name), you should replace `Username-Password-Authentication`
 with your database's name, as it's shown in the Auth0 UI. Click on 'databases'
 in the sidebar of the Auth0 dashboard to view your database(s).
+
+**OPTION B:** Add the `auth0Realm` variable to your `cypress.env.json` file if changing the default value in **OPTION A** is not possible. When using this approach, ensure that the users created for testing use the connection specified by `auth0Realm`.
+```json
+// cypress.env.json
+
+{
+  "auth0Realm": "alt-connection"
+}
+```
 
 **Step 6.3**: Add your cypress port URL (e.g. `http://localhost:3001`) to your
 Auth0 Application's 'Allowed Origins (CORS)' list:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Grant Type:
 
 ![auth0-grant-types](https://user-images.githubusercontent.com/4495352/83317105-6fed3780-a1f8-11ea-8d86-192e7e25f84b.jpg)
 
-**Step 6.2**: 
+**Step 6.2**:
 
 **OPTION A:** Go to your
 [Auth0 tenant's settings](https://manage.auth0.com/#/tenant) (make sure tenant
@@ -131,7 +131,11 @@ default database name), you should replace `Username-Password-Authentication`
 with your database's name, as it's shown in the Auth0 UI. Click on 'databases'
 in the sidebar of the Auth0 dashboard to view your database(s).
 
-**OPTION B:** Add the `auth0Realm` variable to your `cypress.env.json` file if changing the default value in **OPTION A** is not possible. When using this approach, ensure that the users created for testing use the connection specified by `auth0Realm`.
+**OPTION B:** Add the `auth0Realm` variable to your `cypress.env.json` file if
+changing the default value in **OPTION A** is not possible. When using this
+approach, ensure that the users created for testing use the connection specified
+by `auth0Realm`.
+
 ```json
 // cypress.env.json
 

--- a/README.md
+++ b/README.md
@@ -498,13 +498,13 @@ Here are the Cypress environment variables (e.g. in `.env`):
 # .env
 
 # Auth0 Settings
-AUTH0_AUDIENCE="https://lyft.auth0.com/api/v2/",
-AUTH0_DOMAIN="lyft.auth0.com",
-AUTH0_CLIENT_ID="FNfof292fnNFwveldfg9222rf",
-AUTH0_CLIENT_SECRET="FNo3i9f2fbFOdFH8f2fhsooi496bw4uGDif3oDd9fmsS18dDn",
-AUTH0_SECRET="DB208FHFQJFNNA28F0N1F8SBNF8B20FBA0BXSD29SSJAGSL12D9922929D",
-AUTH0_SCOPE="openid profile email",
-AUTH0_SESSION_COOKIE_NAME="appSession",
+AUTH0_AUDIENCE="https://lyft.auth0.com/api/v2/"
+AUTH0_DOMAIN="lyft.auth0.com"
+AUTH0_CLIENT_ID="FNfof292fnNFwveldfg9222rf"
+AUTH0_CLIENT_SECRET="FNo3i9f2fbFOdFH8f2fhsooi496bw4uGDif3oDd9fmsS18dDn"
+AUTH0_SECRET="DB208FHFQJFNNA28F0N1F8SBNF8B20FBA0BXSD29SSJAGSL12D9922929D"
+AUTH0_SCOPE="openid profile email"
+AUTH0_SESSION_COOKIE_NAME="appSession"
 
 # cypress-nextjs-auth0 settings
 AUTH0_LOGOUT_URL="/api/auth/logout"
@@ -519,10 +519,10 @@ AUTH0_RETURN_TO_URL="/"
 # AUTH0_COOKIE_TRANSIENT=
 
 # Test Case Settings
-AUTH0_USERNAME="testuser@lyft.com",
-AUTH0_PASSWORD="mysupersecurepassword",
+AUTH0_USERNAME="testuser@lyft.com"
+AUTH0_PASSWORD="mysupersecurepassword"
 AUTH0_USERNAMEALT="testuser@lyft.com"
-AUTH0_PASSWORDALT="anothersupersecurepassword",
+AUTH0_PASSWORDALT="anothersupersecurepassword"
 ```
 
 Here are the Next.js app variables (e.g. in `cypress/dummy/.env`).

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -18,6 +18,7 @@ module.exports = (on, config) => {
       auth0Password: process.env.AUTH0_PASSWORD,
       auth0Scope: process.env.AUTH0_SCOPE,
       auth0SessionCookieName: process.env.AUTH0_SESSION_COOKIE_NAME,
+      auth0Realm: process.env.AUTH0_REALM,
       // cypress-nextjs-auth0 settings
       auth0LogoutUrl: process.env.AUTH0_LOGOUT_URL,
       auth0ReturnToUrl: process.env.AUTH0_RETURN_TO_URL,

--- a/src/commands/get-user-tokens.js
+++ b/src/commands/get-user-tokens.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('getUserTokens', (credentials = defaultCredentials) => {
         audience: Cypress.env('auth0Audience'),
         scope: Cypress.env('auth0Scope'),
         client_secret: Cypress.env('auth0ClientSecret'), // eslint-disable-line @typescript-eslint/camelcase,
-        realm: Cypress.env('auth0Realm') || 'Username-Password-Authentication'
+        realm: Cypress.env('auth0Realm') || 'Username-Password-Authentication',
       },
       (err, response) => {
         if (err) {

--- a/src/commands/get-user-tokens.js
+++ b/src/commands/get-user-tokens.js
@@ -9,13 +9,14 @@ Cypress.Commands.add('getUserTokens', (credentials = defaultCredentials) => {
   const { username, password } = credentials;
 
   return new Cypress.Promise((resolve, reject) => {
-    auth.client.loginWithDefaultDirectory(
+    auth.client.login(
       {
         username,
         password,
         audience: Cypress.env('auth0Audience'),
         scope: Cypress.env('auth0Scope'),
-        client_secret: Cypress.env('auth0ClientSecret'), // eslint-disable-line @typescript-eslint/camelcase
+        client_secret: Cypress.env('auth0ClientSecret'), // eslint-disable-line @typescript-eslint/camelcase,
+        realm: Cypress.env('auth0Realm') || 'Username-Password-Authentication'
       },
       (err, response) => {
         if (err) {


### PR DESCRIPTION
# Notes

Came across an issue where users created in a non-default connection could not be authorized in testing.

## What I did

- Update the function in `src/commands/get-user-tokens.js` to call `auth.client.login` rather than `auth.client.loginWithDefaultDirectory` to enable specifying the `realm` property in the call. 
- Add default value for realm to "Username-Password-Authentication" as specified in the README.md to prevent breaking existing implementations.
- Update README.md to include the new config variable `auth0Realm`.
- Update README.md to remove breaking commas from example .env files.

## How to test

1. Create a new connection in auth0
2. Enable the connection on your auth0 application
3. Create a new user in auth0 that uses the connection created in step 1
4. Update `cypress.env.json` with the new username/password and add `auth0Realm: <your new connection name>`
5. Run tests
